### PR TITLE
Fix invalid indices in several camera test files

### DIFF
--- a/StandardDataSets/collada/library_cameras/camera/_reference/_reference_optics_orthographic_zfar_znear/_reference_optics_orthographic_zfar_znear.dae
+++ b/StandardDataSets/collada/library_cameras/camera/_reference/_reference_optics_orthographic_zfar_znear/_reference_optics_orthographic_zfar_znear.dae
@@ -112,7 +112,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/_reference/_reference_optics_perspective_zfar_znear/_reference_optics_perspective_zfar_znear.dae
+++ b/StandardDataSets/collada/library_cameras/camera/_reference/_reference_optics_perspective_zfar_znear/_reference_optics_perspective_zfar_znear.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/id/id_dash/id_dash.dae
+++ b/StandardDataSets/collada/library_cameras/camera/id/id_dash/id_dash.dae
@@ -116,7 +116,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
           <input semantic="VERTEX" source="#delete_meShape-vertices" offset="0"/>
           <input semantic="TEXCOORD" source="#delete_meShape-map1" offset="1" set="0"/>
           <vcount>4 4 4 4 4 4</vcount>
-          <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+          <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
 		</polylist>
       </mesh>
     </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/id/id_period/id_period.dae
+++ b/StandardDataSets/collada/library_cameras/camera/id/id_period/id_period.dae
@@ -116,7 +116,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
           <input semantic="VERTEX" source="#delete_meShape-vertices" offset="0"/>
           <input semantic="TEXCOORD" source="#delete_meShape-map1" offset="1" set="0"/>
           <vcount>4 4 4 4 4 4</vcount>
-          <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+          <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
 		</polylist>
       </mesh>
     </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/id/id_underscore/id_underscore.dae
+++ b/StandardDataSets/collada/library_cameras/camera/id/id_underscore/id_underscore.dae
@@ -116,7 +116,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
           <input semantic="VERTEX" source="#delete_meShape-vertices" offset="0"/>
           <input semantic="TEXCOORD" source="#delete_meShape-map1" offset="1" set="0"/>
           <vcount>4 4 4 4 4 4</vcount>
-          <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+          <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
 		</polylist>
       </mesh>
     </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_xmag/optics_orthographic_xmag.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_xmag/optics_orthographic_xmag.dae
@@ -111,7 +111,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_xmag_aspect_ratio/optics_orthographic_xmag_aspect_ratio.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_xmag_aspect_ratio/optics_orthographic_xmag_aspect_ratio.dae
@@ -112,7 +112,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_xmag_ymag/optics_orthographic_xmag_ymag.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_xmag_ymag/optics_orthographic_xmag_ymag.dae
@@ -112,7 +112,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_ymag/optics_orthographic_ymag.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_ymag/optics_orthographic_ymag.dae
@@ -111,7 +111,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_ymag_aspect_ratio/optics_orthographic_ymag_aspect_ratio.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_ymag_aspect_ratio/optics_orthographic_ymag_aspect_ratio.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_zfar/optics_orthographic_zfar.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_zfar/optics_orthographic_zfar.dae
@@ -112,7 +112,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_znear/optics_orthographic_znear.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/orthographic/optics_orthographic_znear/optics_orthographic_znear.dae
@@ -112,7 +112,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_xfov/optics_perspective_xfov.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_xfov/optics_perspective_xfov.dae
@@ -111,7 +111,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_xfov_aspect_ratio/optics_perspective_xfov_aspect_ratio.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_xfov_aspect_ratio/optics_perspective_xfov_aspect_ratio.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_xfov_yfov/optics_perspective_xfov_yfov.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_xfov_yfov/optics_perspective_xfov_yfov.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_yfov/optics_perspective_yfov.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_yfov/optics_perspective_yfov.dae
@@ -114,7 +114,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_yfov_aspect_ratio/optics_perspective_yfov_aspect_ratio.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_yfov_aspect_ratio/optics_perspective_yfov_aspect_ratio.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_zfar/optics_perspective_zfar.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_zfar/optics_perspective_zfar.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-                    <p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                </polylist>
             </mesh>
         </geometry>

--- a/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_znear/optics_perspective_znear.dae
+++ b/StandardDataSets/collada/library_cameras/camera/optics/perspective/optics_perspective_znear/optics_perspective_znear.dae
@@ -115,7 +115,7 @@ dereferenceXRefs=0;cameraXFov=0;cameraYFov=1</comments>
                     <input offset="0" semantic="VERTEX" source="#pCubeShape1-vertices"/>
                     <input offset="1" semantic="TEXCOORD" set="0" source="#pCubeShape1-map1"/>
                     <vcount>4 4 4 4 4 4</vcount>
-					<p>0 0 1 1 3 2 2 3 2 4 3 5 5 6 4 7 4 8 5 9 7 10 6 11 6 12 7 13 1 14 0 15 1 16 7 17 5 18 3 19 6 20 0 21 2 22 4 23</p>
+                    <p>0 0 1 1 3 3 2 2 2 2 3 3 5 5 4 4 4 4 5 5 7 7 6 6 6 6 7 7 1 9 0 8 1 1 7 10 5 11 3 3 6 12 0 0 2 2 4 13</p>
                 </polylist>
             </mesh>
         </geometry>


### PR DESCRIPTION
I think what happened here was that someone copied a geometry that originally had vertex, normal, and texcoord indices. You can see the original geometry in the file `StandardDataSets/1_5/collada/library_animations/animation/asset/unit/unit_blessed.dae`. When copying it over, they deleted the normal source and input and modified the indices. However, they removed the third index instead of the second - making the texcoord offset use the original's normal index values. This resulted in invalid indices into the texcoord array.

I took the original indices and removed the normal offset, putting the correct indices back in their place.
